### PR TITLE
set working directory to project root

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,7 @@ if(WIN32 AND MSVC)
     # set working directory for Visual Studio Debugger
     set_target_properties(
         ${OutputExecutable} PROPERTIES
-        VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
+        VS_DEBUGGER_WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     )
     
     # set subsytem, console if HAS_TERMINAL is true. windows if not


### PR DESCRIPTION
our conversation got me thinking that we could make it so that cmake produces a VS project that already has the working directory at the root of the project.

this will stop the need to have all of those project files be a part of the repo because cmake generates those, we can discuss in more detail privately.