### PR TITLE
comment out emscripten SetWindowTitle implementation

### DIFF
--- a/src/olcPixelGameEngine.h
+++ b/src/olcPixelGameEngine.h
@@ -6568,7 +6568,10 @@ namespace olc
 
 
 		virtual olc::rcode SetWindowTitle(const std::string& s) override
-		{ emscripten_set_window_title(s.c_str()); return olc::OK; }
+		{
+			// emscripten_set_window_title(s.c_str());
+			return olc::OK;
+		}
 
 		virtual olc::rcode StartSystemEventLoop() override 
 		{ return olc::OK; }


### PR DESCRIPTION
PGE, by default, hijack's the browser's title which is undesirable.

To comply with the OLC license I will have a splash screen on the emscripten template, along with the start button that needs to be there to ensure proper sound support across all the browsers.