### PR TITLE
use static_cast to make emscripten happy

### DIFF
--- a/src/HamsterGame.cpp
+++ b/src/HamsterGame.cpp
@@ -163,7 +163,7 @@ void HamsterGame::LoadLevel(const std::string&mapName){
 		for(const LayerTag&layer:currentMap.value().GetData().GetLayers()){
 			for(size_t y:std::ranges::iota_view(0U,layer.tiles.size())){
 				for(size_t x:std::ranges::iota_view(0U,layer.tiles[y].size())){
-					unsigned int tileID{static_cast<unsigned int>(layer.tiles[y][x]-1)};
+					unsigned int tileID{(unsigned int)(layer.tiles[y][x]-1)};
 					if(Powerup::TileIDIsUpperLeftPowerupTile(tileID))mapPowerups.emplace_back(vf2d{float(x),float(y)}*16+vf2d{16,16},Powerup::TileIDPowerupType(tileID));
 					
 					if(tileID==1484)checkpoints.emplace_back(vf2d{float(x),float(y)}*16+vf2d{64,64});

--- a/src/HamsterGame.cpp
+++ b/src/HamsterGame.cpp
@@ -163,7 +163,7 @@ void HamsterGame::LoadLevel(const std::string&mapName){
 		for(const LayerTag&layer:currentMap.value().GetData().GetLayers()){
 			for(size_t y:std::ranges::iota_view(0U,layer.tiles.size())){
 				for(size_t x:std::ranges::iota_view(0U,layer.tiles[y].size())){
-					unsigned int tileID{unsigned int(layer.tiles[y][x]-1)};
+					unsigned int tileID{static_cast<unsigned int>(layer.tiles[y][x]-1)};
 					if(Powerup::TileIDIsUpperLeftPowerupTile(tileID))mapPowerups.emplace_back(vf2d{float(x),float(y)}*16+vf2d{16,16},Powerup::TileIDPowerupType(tileID));
 					
 					if(tileID==1484)checkpoints.emplace_back(vf2d{float(x),float(y)}*16+vf2d{64,64});


### PR DESCRIPTION
I got the following error when trying to build with emscripten. switching to a static_cast seems to fix it.
```
[  7%] Building CXX object CMakeFiles/hamster.dir/src/HamsterGame.cpp.o
/home/jon/Projects/Moros1138/hamster/src/HamsterGame.cpp:166:26: error: non-constant-expression cannot be narrowed from type 'int' to 'unsigned int' in initializer list [-Wc++11-narrowing]
  166 |                                         unsigned int tileID{layer.tiles[y][x]-1};
      |                                                             ^~~~~~~~~~~~~~~~~~~
/home/jon/Projects/Moros1138/hamster/src/HamsterGame.cpp:166:26: note: insert an explicit cast to silence this issue
  166 |                                         unsigned int tileID{layer.tiles[y][x]-1};
      |                                                             ^~~~~~~~~~~~~~~~~~~
```
